### PR TITLE
Fix spelling mistake

### DIFF
--- a/front-end/peer-prep/src/components/Auth/GoodbyePage/index.tsx
+++ b/front-end/peer-prep/src/components/Auth/GoodbyePage/index.tsx
@@ -33,6 +33,6 @@ const GoodbyePlayer = () => {
 }
 
 const goodbyeText = "You have signed out! See you next time!"
-const redirectText = "Stil up for the grind?"
+const redirectText = "Still up for the grind?"
 
 export default GoodbyePage


### PR DESCRIPTION
A small fix to change `Stil` to `Still` text inside goodbye page.