### PR TITLE
Add CORS policy for profile-service

### DIFF
--- a/services/profile-service/src/app.ts
+++ b/services/profile-service/src/app.ts
@@ -6,7 +6,23 @@ import userRoutes from "./router/user-routes";
 
 const app = express();
 
-app.use(cors());
+// Configure CORS to allow our front-end domain to access the APIs
+// Before the end of this project, allows CORS for localhost too
+const corsOptions = {
+	origin: (origin, callback) => {
+	  	const allowedOrigins = [
+			"https://app.peerprepgroup51sem1y2023.xyz",
+			"http://localhost"
+	  	];
+		if (!origin || allowedOrigins.includes(origin)) {
+			callback(null, true);
+		} else {
+			callback(new Error("Not allowed by CORS"));
+		}
+	},
+};
+
+app.use(cors(corsOptions));
 app.use(bodyParser.json());
 
 app.use("/users", userRoutes);


### PR DESCRIPTION
Summary:
1. Added CORS policy for "https://peerprepgroup51sem1y2023.xyz" and "http://localhost". This allows requests from these domains to our profile-service APIs
2. User saving new profile works as well since @zenithyap has modified our front-end to strictly use https APIs only
3. Tested manually on our cloud by running a manual workflow on github actions on `fix-profile-service-cors-policy` to temporarily build a new `profile-service` image and test deployment on our cloud. (It is currently live on our cloud)