### PR TITLE
Update matching worker service dockerfile for production

### DIFF
--- a/Server Configs/docker-compose.yml
+++ b/Server Configs/docker-compose.yml
@@ -114,7 +114,7 @@ services:
     image: "registry.gitlab.com/peerprepgroup51sem1y2023/docker/matching-worker-service:latest"
     environment:
       - AMQP_URL=amqp://rabbitmq:5672
-      - DATABASE_URL=postgresql://root:secret@matching-service-db:5432/matching_service?schema=public
+      - DATABASE_URL=postgresql://root:secret@matching-service-db:5435/matching_service?schema=public
     depends_on:
       - rabbitmq
       - matching-service-db

--- a/services/matching-worker-service/Dockerfile
+++ b/services/matching-worker-service/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=build /app/tsconfig.json ./
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/src ./src
+COPY --from=build /app/prisma ./prisma
 
 # Build the application
 RUN npm run compile

--- a/services/matching-worker-service/prisma/schema.prisma
+++ b/services/matching-worker-service/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://root:secret@35.240.242.81:5432/matching_service?schema=public"
+  url      = "postgresql://root:secret@35.240.242.81:5435/matching_service?schema=public"
 }
 
 model MatchRequest {

--- a/services/matching-worker-service/prisma/schema.prisma
+++ b/services/matching-worker-service/prisma/schema.prisma
@@ -8,7 +8,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = "postgresql://root:secret@35.240.242.81:5432/matching_service?schema=public"
 }
 
 model MatchRequest {


### PR DESCRIPTION
Summary:
1. Changed ingress port mapping for matching-service db to prevent port conflict with another postgres db port mapping
2.  Add prisma folder to last stage of dockerfile for production for migration to work
3. Edited ingress port forwarding rules in Google Cloud firewall temporarily to expose matching-service-db for migration to work