### PR TITLE
Add logging to matching service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,14 @@
 version: "3.4"
 
 services:
-    # judge0:
-    #     image: judge0/judge0:latest
-    #     ports:
-    #         - "8080:80"
-    #     environment:
-    #         - JUDGE0_API_DOMAIN=your-judge0-domain
-    #         - JUDGE0_USE_REDIS=false
-    #         - JUDGE0_STORAGE_PATH=/sandbox
+    judge0:
+        image: judge0/judge0:latest
+        ports:
+            - "8080:80"
+        environment:
+            - JUDGE0_API_DOMAIN=your-judge0-domain
+            - JUDGE0_USE_REDIS=false
+            - JUDGE0_STORAGE_PATH=/sandbox
     # front-end:
     #     container_name: front-end
     #     image: front-end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
 # For local development purposes only
 
-version: "3"
+version: "3.4"
 
 services:
-    judge0:
-        image: judge0/judge0:latest
-        ports:
-            - "8080:80"
-        environment:
-            - JUDGE0_API_DOMAIN=your-judge0-domain
-            - JUDGE0_USE_REDIS=false
-            - JUDGE0_STORAGE_PATH=/sandbox
+    # judge0:
+    #     image: judge0/judge0:latest
+    #     ports:
+    #         - "8080:80"
+    #     environment:
+    #         - JUDGE0_API_DOMAIN=your-judge0-domain
+    #         - JUDGE0_USE_REDIS=false
+    #         - JUDGE0_STORAGE_PATH=/sandbox
     # front-end:
     #     container_name: front-end
     #     image: front-end
@@ -22,14 +22,8 @@ services:
     question-service:
         container_name: question-service
         image: question-service
-
-        # Uncomment for testing with k8s
-        # build:
-        #     context: ./services/question-service
-        # ports:
-        #     - 8080:8080
-
-        # Uncomment for hot reloading
+        ports:
+            - 8080:8080
         build:
             context: ./services/question-service
             target: build
@@ -55,7 +49,7 @@ services:
         image: postgres
         restart: always
         ports:
-            - "5432:5432"
+            - 5433:5433
 
     profile-service:
         container_name: profile-service
@@ -96,6 +90,12 @@ services:
         ports:
             - 5672:5672
             - 15672:15672
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:15672"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 40s
 
     matching-worker-service:
         container_name: matching-worker-service
@@ -112,6 +112,7 @@ services:
         links:
             - rabbitmq
             - matching-service-db
+        restart: on-failure
         volumes:
             - ./services/matching-worker-service:/app
 

--- a/services/matching-service/src/handlers/matchRequestHandler.ts
+++ b/services/matching-service/src/handlers/matchRequestHandler.ts
@@ -14,6 +14,7 @@ const registerMatchRequestHandlers = (
   channel: Channel
 ) => {
   const createMatchRequest = async (data: any) => {
+    console.log("creating match request with ", data);
     try {
       const matchRequest = await validateMatchRequestPromise(data);
       const correlationId = randomUUID();
@@ -25,6 +26,10 @@ const registerMatchRequestHandlers = (
           if (!message) {
             return;
           }
+          console.log(
+            `match found, returning match object 
+            ${message.content.toString()} to ${data.userId}`
+          );
           socket.emit("match-response:success", message.content.toString());
           socket.disconnect();
           isMatchFound = true;
@@ -40,6 +45,7 @@ const registerMatchRequestHandlers = (
 
       setTimeout(async () => {
         if (!isMatchFound) {
+          console.log(`match not found for user ${data.userId}`);
           socket.emit("match-response:failure");
           socket.disconnect();
         }

--- a/services/matching-worker-service/package.json
+++ b/services/matching-worker-service/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "tsc",
     "start": "node dist/index.js",
-    "dev": "ts-node-dev --poll --respawn --transpile-only src/index.ts",
+    "dev": "ts-node-dev --poll --transpile-only src/index.ts",
     "start:migrate:dev": "npx prisma migrate dev && npm run dev",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prisma:generate": "npx prisma generate",

--- a/services/matching-worker-service/src/index.ts
+++ b/services/matching-worker-service/src/index.ts
@@ -93,5 +93,7 @@ const amqpConnectionPromise = getQueueConnection(amqpUrl);
     });
   } catch (err) {
     console.error(err);
+    console.log("exiting");
+    process.exit(1);
   }
 })();

--- a/services/matching-worker-service/src/index.ts
+++ b/services/matching-worker-service/src/index.ts
@@ -28,6 +28,8 @@ const amqpConnectionPromise = getQueueConnection(amqpUrl);
       const matchRequest = JSON.parse(msg.content.toString());
       const correlationId = msg.properties.correlationId;
 
+      console.log(`received match request ${JSON.stringify(matchRequest)}`);
+
       const matchRequestEntry = await prisma.matchRequest.create({
         data: {
           ...matchRequest,
@@ -57,6 +59,7 @@ const amqpConnectionPromise = getQueueConnection(amqpUrl);
       if (!compatibleMatch) {
         return;
       }
+      console.log(`found compatible match ${JSON.stringify(compatibleMatch)}`);
 
       const matchId = randomUUID();
       const userId1 = matchRequest.userId;


### PR DESCRIPTION
* Add console logging to print json data being consumed and generated
* Fix healthcheck bug - now local docker-compose can automatically restart matching-worker-service until rabbitmq is ready